### PR TITLE
Disable encoding of defaults in GeminiAI JSON serialization

### DIFF
--- a/src/commonMain/kotlin/io/github/ugaikit/gemini4kt/GeminiAI.kt
+++ b/src/commonMain/kotlin/io/github/ugaikit/gemini4kt/GeminiAI.kt
@@ -28,7 +28,7 @@ class GeminiAI(
     private val json =
         Json {
             ignoreUnknownKeys = true
-            encodeDefaults = true
+            encodeDefaults = false
             explicitNulls = false
         }
 

--- a/src/commonMain/kotlin/io/github/ugaikit/gemini4kt/samples/InteractionSamples.kt
+++ b/src/commonMain/kotlin/io/github/ugaikit/gemini4kt/samples/InteractionSamples.kt
@@ -18,7 +18,7 @@ object InteractionSamples {
     private val json =
         Json {
             ignoreUnknownKeys = true
-            encodeDefaults = true
+            encodeDefaults = false
         }
 
     suspend fun runSimple(client: GeminiAI? = null) {

--- a/src/commonTest/kotlin/io/github/ugaikit/gemini4kt/GeminiAITest.kt
+++ b/src/commonTest/kotlin/io/github/ugaikit/gemini4kt/GeminiAITest.kt
@@ -33,7 +33,7 @@ class GeminiAITest {
                     json(
                         Json {
                             ignoreUnknownKeys = true
-                            encodeDefaults = true
+                            encodeDefaults = false
                             explicitNulls = false
                         },
                     )

--- a/src/commonTest/kotlin/io/github/ugaikit/gemini4kt/samples/InteractionSamplesTest.kt
+++ b/src/commonTest/kotlin/io/github/ugaikit/gemini4kt/samples/InteractionSamplesTest.kt
@@ -27,7 +27,7 @@ class InteractionSamplesTest {
                     json(
                         Json {
                             ignoreUnknownKeys = true
-                            encodeDefaults = true
+                            encodeDefaults = false
                             explicitNulls = false
                         },
                     )


### PR DESCRIPTION
- Updated `GeminiAI` and `InteractionSamples` JSON configuration to `encodeDefaults = false`.
- This ensures that null properties (which are default values) are not serialized into the JSON payload.
- This fixes issues where the server rejects requests due to unexpected null fields (e.g., `arguments: null` in `TextContent`) caused by polymorphic type validation.
- Updated unit tests to match the new configuration logic.