### PR TITLE
feat(computerUse): add builder, serialization, Tool support, samples

### DIFF
--- a/src/commonMain/kotlin/io/github/ugaikit/gemini4kt/ComputerUse.kt
+++ b/src/commonMain/kotlin/io/github/ugaikit/gemini4kt/ComputerUse.kt
@@ -1,5 +1,6 @@
 package io.github.ugaikit.gemini4kt
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
@@ -15,5 +16,60 @@ import kotlin.js.JsExport
 @Serializable
 data class ComputerUse(
     val environment: Environment? = null,
+    @SerialName("excluded_predefined_functions")
     val excludedPredefinedFunctions: Array<String>? = null,
 )
+
+/**
+ * Represents the computer use builder.
+ */
+class ComputerUseBuilder {
+    /**
+     * Holds the environment.
+     */
+    var environment: Environment? = null
+
+    /**
+     * Holds the excluded predefined functions.
+     */
+    private var excludedPredefinedFunctions: MutableList<String> = mutableListOf()
+
+    /**
+     * Handles excluded predefined function.
+     *
+     * @param name The predefined function name to exclude.
+     */
+    fun excludedPredefinedFunction(name: String) {
+        excludedPredefinedFunctions.add(name)
+    }
+
+    /**
+     * Handles excluded predefined functions.
+     *
+     * @param names The predefined function names to exclude.
+     */
+    fun excludedPredefinedFunctions(vararg names: String) {
+        excludedPredefinedFunctions.addAll(names)
+    }
+
+    /**
+     * Handles build.
+     */
+    fun build() =
+        ComputerUse(
+            environment = environment,
+            excludedPredefinedFunctions =
+                if (excludedPredefinedFunctions.isEmpty()) {
+                    null
+                } else {
+                    excludedPredefinedFunctions.toTypedArray()
+                },
+        )
+}
+
+/**
+ * Handles computer use config.
+ *
+ * @param init The init.
+ */
+fun computerUse(init: ComputerUseBuilder.() -> Unit): ComputerUse = ComputerUseBuilder().apply(init).build()

--- a/src/commonMain/kotlin/io/github/ugaikit/gemini4kt/Tool.kt
+++ b/src/commonMain/kotlin/io/github/ugaikit/gemini4kt/Tool.kt
@@ -34,6 +34,7 @@ data class Tool(
     @SerialName("file_search")
     val fileSearch: FileSearchTool? = null,
     val googleSearchRetrieval: GoogleSearchRetrieval? = null,
+    @SerialName("computer_use")
     val computerUse: ComputerUse? = null,
     val mcpServers: Array<McpServer>? = null,
     val googleMaps: GoogleMaps? = null,
@@ -143,6 +144,15 @@ class ToolBuilder {
      */
     fun computerUse(computerUse: ComputerUse) {
         this.computerUse = computerUse
+    }
+
+    /**
+     * Handles computer use.
+     *
+     * @param init The init.
+     */
+    fun computerUse(init: ComputerUseBuilder.() -> Unit) {
+        this.computerUse = ComputerUseBuilder().apply(init).build()
     }
 
     /**

--- a/src/commonMain/kotlin/io/github/ugaikit/gemini4kt/interaction/InteractionTool.kt
+++ b/src/commonMain/kotlin/io/github/ugaikit/gemini4kt/interaction/InteractionTool.kt
@@ -31,6 +31,7 @@ data class InteractionTool(
     val description: String? = null,
     val parameters: JsonElement? = null,
     val environment: String? = null,
+    @SerialName("excluded_predefined_functions")
     val excludedPredefinedFunctions: Array<String>? = null,
     val url: String? = null,
     val headers: JsonElement? = null,

--- a/src/commonMain/kotlin/io/github/ugaikit/gemini4kt/samples/ComputerUseGemini35Sample.kt
+++ b/src/commonMain/kotlin/io/github/ugaikit/gemini4kt/samples/ComputerUseGemini35Sample.kt
@@ -1,0 +1,41 @@
+package io.github.ugaikit.gemini4kt.samples
+
+import io.github.ugaikit.gemini4kt.GeminiAI
+import io.github.ugaikit.gemini4kt.getApiKey
+import io.github.ugaikit.gemini4kt.interaction.CreateInteractionRequest
+import io.github.ugaikit.gemini4kt.interaction.InteractionTool
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Represents a Computer Use sample using gemini-3.5-flash and the Interactions API.
+ */
+object ComputerUseGemini35Sample {
+    /**
+     * Sends a small Computer Use request using the Interactions API.
+     *
+     * If `gemini` is null, a new GeminiAI client is created using `getApiKey()`.
+     *
+     * @param gemini Optional GeminiAI client to use for the request; when null a client
+     *   is constructed from `getApiKey()`.
+     */
+    suspend fun run(gemini: GeminiAI? = null) {
+        val client = gemini ?: GeminiAI(apiKey = getApiKey())
+        val request =
+            CreateInteractionRequest(
+                model = "gemini-3.5-flash",
+                input = JsonPrimitive("Search for 'Gemini API' on Google."),
+                tools =
+                    arrayOf(
+                        InteractionTool(
+                            type = "computer_use",
+                            environment = "browser",
+                        ),
+                    ),
+            )
+
+        val response =
+            client.createInteraction(request)
+
+        println(response)
+    }
+}

--- a/src/commonMain/kotlin/io/github/ugaikit/gemini4kt/samples/ComputerUseSample.kt
+++ b/src/commonMain/kotlin/io/github/ugaikit/gemini4kt/samples/ComputerUseSample.kt
@@ -1,0 +1,42 @@
+package io.github.ugaikit.gemini4kt.samples
+
+import io.github.ugaikit.gemini4kt.GeminiAI
+import io.github.ugaikit.gemini4kt.getApiKey
+import io.github.ugaikit.gemini4kt.interaction.CreateInteractionRequest
+import io.github.ugaikit.gemini4kt.interaction.InteractionTool
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Represents the legacy computer use sample for Gemini 2.5.
+ */
+object ComputerUseSample {
+    /**
+     * Sends a small Computer Use request using the legacy Interactions API.
+     *
+     * If `gemini` is null, a new GeminiAI client is created using `getApiKey()`.
+     *
+     * @param gemini Optional GeminiAI client to use for the request; when null a client
+     *   is constructed from `getApiKey()`.
+     */
+    suspend fun run(gemini: GeminiAI? = null) {
+        val client = gemini ?: GeminiAI(apiKey = getApiKey())
+        val request =
+            CreateInteractionRequest(
+                model = "gemini-2.5-computer-use-preview-10-2025",
+                input = JsonPrimitive("Search for 'Gemini API' on Google."),
+                tools =
+                    arrayOf(
+                        InteractionTool(
+                            type = "computer_use",
+                            environment = "browser",
+                            excludedPredefinedFunctions = arrayOf("CLICK"),
+                        ),
+                    ),
+            )
+
+        val response =
+            client.createInteraction(request)
+
+        println(response)
+    }
+}

--- a/src/commonTest/kotlin/io/github/ugaikit/gemini4kt/ToolBuilderTest.kt
+++ b/src/commonTest/kotlin/io/github/ugaikit/gemini4kt/ToolBuilderTest.kt
@@ -154,12 +154,10 @@ class ToolBuilderTest {
                             ),
                     ),
                 )
-                computerUse(
-                    ComputerUse(
-                        environment = Environment.ENVIRONMENT_BROWSER,
-                        excludedPredefinedFunctions = arrayOf("CLICK"),
-                    ),
-                )
+                computerUse {
+                    environment = Environment.ENVIRONMENT_BROWSER
+                    excludedPredefinedFunction("CLICK")
+                }
                 mcpServer(
                     McpServer(
                         name = "mcp-server",
@@ -187,5 +185,21 @@ class ToolBuilderTest {
         assertEquals("CLICK", decoded.computerUse?.excludedPredefinedFunctions?.first())
         assertEquals("mcp-server", decoded.mcpServers?.first()?.name)
         assertEquals(true, decoded.googleMaps?.enableWidget)
+        assertEquals(true, encoded.contains("\"computer_use\""))
+        assertEquals(true, encoded.contains("\"excluded_predefined_functions\""))
+    }
+
+    @Test
+    fun testComputerUseBuilder() {
+        val computerUse =
+            computerUse {
+                environment = Environment.ENVIRONMENT_BROWSER
+                excludedPredefinedFunctions("CLICK", "TYPE")
+            }
+
+        assertEquals(Environment.ENVIRONMENT_BROWSER, computerUse.environment)
+        assertEquals(2, computerUse.excludedPredefinedFunctions?.size)
+        assertEquals("CLICK", computerUse.excludedPredefinedFunctions?.first())
+        assertEquals("TYPE", computerUse.excludedPredefinedFunctions?.last())
     }
 }

--- a/src/commonTest/kotlin/io/github/ugaikit/gemini4kt/interaction/InteractionSerializationTest.kt
+++ b/src/commonTest/kotlin/io/github/ugaikit/gemini4kt/interaction/InteractionSerializationTest.kt
@@ -79,6 +79,24 @@ class InteractionSerializationTest {
     }
 
     @Test
+    fun interactionToolSerializesComputerUseConfig() {
+        val tool =
+            InteractionTool(
+                type = "computer_use",
+                environment = "browser",
+                excludedPredefinedFunctions = arrayOf("CLICK", "TYPE"),
+            )
+
+        val encoded = json.encodeToString(tool)
+
+        assertTrue(encoded.contains("\"computer_use\""))
+        assertTrue(encoded.contains("\"excluded_predefined_functions\""))
+
+        val decoded = json.decodeFromString<InteractionTool>(encoded)
+        assertEquals(tool, decoded)
+    }
+
+    @Test
     fun interactionEnumSerializesToSnakeCase() {
         val statusJson = json.encodeToString(InteractionStatus.IN_PROGRESS)
         assertEquals("\"in_progress\"", statusJson)


### PR DESCRIPTION
- Add ComputerUse builder + computerUse DSL to build config
- Serialize excludedPredefinedFunctions as excluded_predefined_functions
- Wire ComputerUse into Tool and ToolBuilder with computerUse init overload
- Add samples for legacy and gemini-3.5 Computer Use interactions
- Add tests for serialization and builder; update ToolBuilderTest assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more convenient way to configure computer-use settings with a builder-style syntax.
  * Added sample code showing how to use computer-use interactions in both newer and legacy flows.

* **Bug Fixes**
  * Corrected JSON field mapping for computer-use settings so they serialize and deserialize as expected.
  * Improved support for excluding predefined actions when configuring computer-use tools.

* **Tests**
  * Expanded serialization and builder tests to verify computer-use configurations are encoded correctly and round-trip successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->